### PR TITLE
Updates tokenizer to correctly parse `/*comment*/index`

### DIFF
--- a/lib/rkelly/constants.rb
+++ b/lib/rkelly/constants.rb
@@ -1,3 +1,3 @@
 module RKelly
-  VERSION = '1.0.5'
+  VERSION = '1.0.6'
 end

--- a/lib/rkelly/token.rb
+++ b/lib/rkelly/token.rb
@@ -11,5 +11,9 @@ module RKelly
       return transformer.call(name, value) if transformer
       [name, value]
     end
+
+    def to_s
+      return "#{self.name}: #{self.value}"
+    end
   end
 end

--- a/lib/rkelly/tokenizer.rb
+++ b/lib/rkelly/tokenizer.rb
@@ -90,7 +90,16 @@ module RKelly
         end
       end
 
-      token(:REGEXP, /\A\/(?:[^\/\r\n\\]*(?:\\[^\r\n][^\/\r\n\\]*)*)\/[gi]*/)
+      # To distinguish regular expressions from comments, we require that
+      # regular expressions start with a non * character (ie, not look like
+      # /*foo*/). Note that we can't depend on the length of the match to
+      # correctly distinguish, since `/**/i` is longer if matched as a regular
+      # expression than as matched as a comment.
+      # Incidentally, we're also not matching empty regular expressions
+      # (eg, // and //g). Here we could depend on match length and priority to
+      # determine that these are actually comments, but it turns out to be
+      # easier to not match them in the first place.
+      token(:REGEXP, /\A\/(?:[^\/\r\n\\*]|\\[^\r\n])[^\/\r\n\\]*(?:\\[^\r\n][^\/\r\n\\]*)*\/[gi]*/)
       token(:S, /\A[\s\r\n]*/m)
 
       token(:SINGLE_CHAR, /\A./) do |type, value|

--- a/test/test_tokenizer.rb
+++ b/test/test_tokenizer.rb
@@ -127,6 +127,14 @@ class TokenizerTest < Test::Unit::TestCase
     end
   end
 
+  def test_regular_expression_is_not_found_if_block_comment_with_re_modifier
+    tokens = @tokenizer.tokenize("/**/i")
+    assert_tokens([
+      [:COMMENT, "/**/"],
+      [:IDENT, "i"]
+    ], tokens)
+  end
+
   def test_comment_assign
     tokens = @tokenizer.tokenize("foo = /**/;")
     assert_tokens([


### PR DESCRIPTION
The tokenizer looks for the longest string it can match, and breaks ties based on COMMENTS > ... > REGEXP.

According to its matching rules, though `/*comment*/index` would make an eleven character comment (`/*comment*/`) or a twelve character regexp (`/*comment*/i`).

This change requires that the meat of regular expressions not start with a `*` so as to fix this problem.
