### PR TITLE
lib breaks on ruby 1.9.3 because of a regexp that is not compatible

### DIFF
--- a/lib/rkelly/visitors/evaluation_visitor.rb
+++ b/lib/rkelly/visitors/evaluation_visitor.rb
@@ -315,7 +315,7 @@ module RKelly
           when Numeric
             object.value
           when ::String
-            s = object.value.gsub(/(\A[\s\xA0]*|[\s\xA0]*\Z)/, '')
+            s = object.value.gsub(/(\A[\s\xA0]*|[\s\xA0]*\Z)/n, '')
             if s.length == 0
               0
             else


### PR DESCRIPTION
There's been some changes to ruby's multibyte escaping rules since 1.9.3. In light of that, rkelly now has a SyntaxError when you attempt to use on 1.9.3.

```
`require': [..]lib/rkelly/visitors/evaluation_visitor.rb:318:
invalid multibyte escape: /(\A[\s\xA0]*|[\s\xA0]*\Z)/ (SyntaxError)
```

The solution to this is that regexes containing multi-byte characters must be explicitly marked as such. There is some discussion on [ruby-forum](http://www.ruby-forum.com/topic/183413) on how this should be marked. They mostly suggest using `Regexp.new 'foo\xA0', nil, 'n'`, but I found out that the much more terse `/foo\xA0/n` would work just fine.
