### PR TITLE
Saving number of lines in the node

### DIFF
--- a/lib/rkelly/nodes/node.rb
+++ b/lib/rkelly/nodes/node.rb
@@ -5,11 +5,11 @@ module RKelly
       include RKelly::Visitors
       include Enumerable
 
-      attr_accessor :value, :comments, :line, :filename
+      attr_accessor :value, :comments, :line, :lines, :filename
       def initialize(value)
         @value = value
         @comments = []
-        @filename = @line = nil
+        @filename = @line = @lines = nil
       end
 
       def ==(other)

--- a/lib/rkelly/parser.rb
+++ b/lib/rkelly/parser.rb
@@ -13,8 +13,9 @@ module RKelly
           r = super(val.map { |v|
               v.is_a?(Token) ? v.to_racc_token[1] : v
             }, _values, result)
-          if token = val.find { |v| v.is_a?(Token) }
-            r.line = token.line if r.respond_to?(:line)
+          unless (tokens = val.select { |v| v.is_a?(Token) }).empty?
+            r.line = tokens.first.line if r.respond_to?(:line)
+            r.lines = tokens.last.line - tokens.first.line + 1 if r.respond_to?(:lines)
             r.filename = @filename if r.respond_to?(:filename)
           end
           r

--- a/test/test_line_number.rb
+++ b/test/test_line_number.rb
@@ -9,15 +9,18 @@ class LineNumberTest < NodeTestCase
        */
       function aaron() {
         var x = 10;
-        return 1 + 1;
+        return 1 
+        + 1;
       }
     eojs
     func = ast.pointcut(FunctionDeclNode).matches.first
     assert func
     assert_equal(4, func.line)
+    assert_equal(5, func.lines)
 
     return_node = ast.pointcut(ReturnNode).matches.first
     assert return_node
     assert_equal(6, return_node.line)
+    assert_equal(2, return_node.lines)
   end
 end


### PR DESCRIPTION
Preserving number of lines helps to map nodes back to source. 
