### PR TITLE
Speed up Tokenizer about 30 x

### DIFF
--- a/lib/rkelly/lexeme.rb
+++ b/lib/rkelly/lexeme.rb
@@ -9,8 +9,8 @@ module RKelly
       @block      = block
     end
 
-    def match(string)
-      match = pattern.match(string)
+    def match(scanner)
+      match = scanner.check(pattern)
       return Token.new(name, match.to_s, &@block) if match
       match
     end

--- a/lib/rkelly/tokenizer.rb
+++ b/lib/rkelly/tokenizer.rb
@@ -1,4 +1,5 @@
 require 'rkelly/lexeme'
+require 'strscan'
 
 module RKelly
   class Tokenizer
@@ -112,16 +113,17 @@ module RKelly
     end
 
     def raw_tokens(string)
+      scanner = StringScanner.new(string)
       tokens = []
       line_number = 1
       accepting_regexp = true
-      while string.length > 0
+      while !scanner.eos?
         longest_token = nil
 
         @lexemes.each { |lexeme|
           next if lexeme.name == :REGEXP && !accepting_regexp
 
-          match = lexeme.match(string)
+          match = lexeme.match(scanner)
           next if match.nil?
           longest_token = match if longest_token.nil?
           next if longest_token.value.length >= match.value.length
@@ -134,7 +136,7 @@ module RKelly
 
         longest_token.line = line_number
         line_number += longest_token.value.scan(/\n/).length
-        string = string.slice(Range.new(longest_token.value.length, -1))
+        scanner.pos += longest_token.value.length
         tokens << longest_token
       end
       tokens


### PR DESCRIPTION
Slicing the string after each token made the tokenizing process
really slow.

I eliminated this inneficency by using Ruby's builtin StringScanner,
that's well suited for this task.

Before this change, it took about 14 seconds to tokenize a 3000-line
JavaScript file.  Now it takes just about 0.4 seconds.  That's about
30 x speedup.

It's still slow in my opinion, but at least it's not dead-slow any more.
