### PR TITLE
Fix ecma visitor for function expressions with name.

### DIFF
--- a/lib/rkelly/visitors/ecma_visitor.rb
+++ b/lib/rkelly/visitors/ecma_visitor.rb
@@ -87,9 +87,7 @@ module RKelly
       end
 
       def visit_FunctionDeclNode(o)
-        "#{indent}function #{o.value}(" +
-          "#{o.arguments.map { |x| x.accept(self) }.join(', ')})" +
-          "#{o.function_body.accept(self)}"
+        "#{indent}function #{o.value}" + function_params_and_body(o)
       end
 
       def visit_ParameterNode(o)
@@ -269,15 +267,21 @@ module RKelly
       end
 
       def visit_GetterPropertyNode(o)
-        "get #{o.name}#{o.value.accept(self)}"
+        "get #{o.name}" + function_params_and_body(o.value)
       end
 
       def visit_SetterPropertyNode(o)
-        "set #{o.name}#{o.value.accept(self)}"
+        "set #{o.name}" + function_params_and_body(o.value)
       end
 
       def visit_FunctionExprNode(o)
-        "#{o.value}(#{o.arguments.map { |x| x.accept(self) }.join(', ')}) " +
+        name = (o.value == 'function') ? '' : ' '+o.value
+        "function" + name + function_params_and_body(o)
+      end
+
+      # Helper for all the various function nodes
+      def function_params_and_body(o)
+        "(#{o.arguments.map { |x| x.accept(self) }.join(', ')}) " +
           "#{o.function_body.accept(self)}"
       end
 

--- a/test/test_ecma_visitor.rb
+++ b/test/test_ecma_visitor.rb
@@ -9,6 +9,9 @@ class ECMAVisitorTest < Test::Unit::TestCase
     assert_to_ecma('a = function() { };')
   end
 
+  def test_named_function_expr
+    assert_to_ecma('a = function b() { };')
+  end
 
   def test_this_node
     assert_to_ecma('this.foo;')


### PR DESCRIPTION
To fix issue #27

Make the Getter and Setter visitors also handle the visiting of the
related FunctionExprNode, not rely on the visit_FunctionExprNode, which
can accordingly be changed to also include "function" before its name.

To DRY things up, move the common bit of all the Function-visiting
methods to #function_params_and_body helper method.

Also add a test case.
