### PR TITLE
Update list of reserved words to match ECMAScript 5.

### DIFF
--- a/lib/rkelly/tokenizer.rb
+++ b/lib/rkelly/tokenizer.rb
@@ -11,11 +11,15 @@ module RKelly
       const true false null debugger
     }
 
+    # First 6 are always reserved in ECMAScript 5.1
+    # Others are only reserved in strict mode.
+    # http://www.ecma-international.org/ecma-262/5.1/#sec-7.6.1.2
+    # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Reserved_Words
     RESERVED = %w{
-      abstract boolean byte char class double enum export extends
-      final float goto implements import int interface long native package
-      private protected public short static super synchronized throws
-      transient volatile
+      class enum export extends import super
+
+      implements interface package private protected public static
+      let yield
     }
 
     LITERALS = {


### PR DESCRIPTION
Fixes issue #28

ES5 removed a bunch of reserved words that ES3 had reserved.  These
are also supported as identifiers by real-world implementations. So
removing these.

ES5 added 'let' and 'yield' to the reserved list, which have been added
in here too.
