### PR TITLE
Fix inadvertent automatic semicolon insertion

### DIFF
--- a/lib/rkelly/parser.rb
+++ b/lib/rkelly/parser.rb
@@ -27,6 +27,7 @@ module RKelly
       @tokens = []
       @logger = nil
       @terminator = false
+      @for_header_parentheses = 0
       @prev_token = nil
       @comments = []
     end
@@ -88,7 +89,21 @@ module RKelly
         end
       end while([:COMMENT, :S].include?(n_token.name))
 
+
+      if '(' == n_token.value
+        if 'for' == @prev_token.value
+          @for_header_parentheses = 1
+        elsif @for_header_parentheses > 0
+          @for_header_parentheses += 1
+        end
+      end
+
+      if ')' == n_token.value && @for_header_parentheses > 0
+        @for_header_parentheses -= 1
+      end
+
       if @terminator &&
+          0 == @for_header_parentheses &&
           ((@prev_token && %w[continue break return throw].include?(@prev_token.value)) ||
            (n_token && %w[++ --].include?(n_token.value)))
         @position -= 1

--- a/test/test_automatic_semicolon_insertion.rb
+++ b/test/test_automatic_semicolon_insertion.rb
@@ -132,14 +132,6 @@ class AutomaticSemicolonInsertionTest < Test::Unit::TestCase
   end
 
   def test_no_for_insertion_with_prefix_plus_plus
-    # RKelly erroneously inserts a semicolon after `b`:
-    assert_sexp([[:for, [:resolve, 'a'],
-                        [:resolve, 'b'],
-                        [:prefix, [:resolve, 'c'], '++'],
-                        [:block, []]]],
-                @parser.parse("for (a;\nb\n++c){}"))
-
-    # This correct code, on the other hand, fails to parse.
     assert_sexp([[:for, [:resolve, 'a'],
                         [:resolve, 'b'],
                         [:prefix, [:resolve, 'c'], '++'],


### PR DESCRIPTION
This patch fixes a bug in RKelly's automatic semicolon insertion logic: though the ECMAScript standard specifies that automatic semicolon insertion never takes place within the header of a `for` loop, this valid code would fail to parse:

```
    for(a;
        b;
        ++c) { /* ... */ }
```

...because RKelly erroneously attempts to insert a semicolon after `b`, which would be a valid insertion anywhere outside the header of a `for` loop.

To fix this, this modifies `RKelly::Parser` to explicitly track when we're inside the loop header, including any nested parenthetical sub-expressions, so it won't attempt to insert a semicolon.

(CCing @nene for rkelly-remix, too.)
